### PR TITLE
Import pathes was fixed

### DIFF
--- a/code/color_space/view/view.py
+++ b/code/color_space/view/view.py
@@ -1,12 +1,12 @@
 import tkinter as tk
 from tkinter import ttk
 
-from color_space.viewmodel import view_model
+from color_space.viewmodel import viewmodel
 
 
 class GUI(ttk.Frame):
     default_sticky = tk.W + tk.E + tk.N + tk.S
-    view_model = view_model.ViewModel()
+    view_model = viewmodel.ViewModel()
 
     def bind_events(self):
         self.btn_convert.bind('<Button-1>', self.convert_clicked)

--- a/code/fraction/cliview/cli_view.py
+++ b/code/fraction/cliview/cli_view.py
@@ -1,11 +1,11 @@
 import os
 import sys
 
-from viewmodel import viewmodel
+from fraction.viewmodel import viewmodel
 
 
 class CLIView:
-    view_model = viewmodel.ViewModel()
+    view_model = viewmodel.FractionViewModel()
     WIDTH = 80
     message_text = ''
     first_fraction = ''

--- a/code/fraction/guiview/gui_view.py
+++ b/code/fraction/guiview/gui_view.py
@@ -1,7 +1,7 @@
 import tkinter
 from tkinter import ttk
 
-from fraction.viewmodel.viewmodel import viewmodel
+from fraction.viewmodel import viewmodel
 
 
 class GUIView(ttk.Frame):
@@ -9,7 +9,7 @@ class GUIView(ttk.Frame):
     N_LOG_MESSAGES_TO_DISPLAY = 15
     default_sticky = tkinter.W + tkinter.E + tkinter.N + tkinter.S
 
-    view_model = viewmodel.ViewModel()
+    view_model = viewmodel.FractionViewModel()
 
     def set_weight_to_grid(self):
         self.rowconfigure(1, weight=1)

--- a/code/matrix/gui_view/gui_view.py
+++ b/code/matrix/gui_view/gui_view.py
@@ -1,6 +1,6 @@
 import tkinter as Tk
 
-from matrix.viewmodel import view_model
+from matrix.viewmodel import viewmodel
 
 
 class SimpleTableInput(Tk.Frame):
@@ -49,7 +49,7 @@ class GuiView(Tk.Frame):
         Tk.Frame.__init__(self)
         self.count_log_messages = 6
 
-        self.view_model = view_model.ViewModel()
+        self.view_model = viewmodel.MatrixViewModel()
         self.master.title("Determinant calculator")
         self.master.minsize(width=150, height=150)
 


### PR DESCRIPTION
Tested on Windows and it works. 
To make project modules available to use from another modules by current paths, need to create environment variable PYTHONPATH with path to /code folder - we can add it into instructions